### PR TITLE
support LogSoftMax model, MSECriterion and ClassNLLCriterion

### DIFF
--- a/doc/rop.md
+++ b/doc/rop.md
@@ -6,46 +6,49 @@ optimization, or to calculate the full Hessian by repeatedly multiply
 with one-hot vectors.
 
 ## Example
-Given the following function,
-```
-h = σ(Wx + b)
-y = σ(Wh + b)
-E = sum(y)
-```
-this code calculates the product of the Hessian with a vector of ones.
+We use MLP to illustrate how to use R-op, the following codes compute the product
+of the Hessian with a random vector.
+
 ```lua
-local mini_batch_size = 11
-local input = torch.randn(mini_batch_size, 3)
+local input_size = 3
+local target_size = 3
+local hidden_size = 2
+local mini_batch_size = 10
+
+local input = torch.randn(mini_batch_size, input_size)
+local target = torch.ceil(torch.rand(mini_batch_size)*target_size)
 
 local model = nn.Sequential()
-   model:add(nn.Linear(3, 2))
+   model:add(nn.Linear(input_size, hidden_size))
    model:add(nn.Sigmoid())
-   model:add(nn.Linear(2, 4))
-   model:add(nn.Sigmoid())
+   model:add(nn.Linear(hidden_size, target_size))
+   model:add(nn.LogSoftMax())
+--local criterion = nn.MSECriterion()
+local criterion = nn.ClassNLLCriterion()
 
 -- We must collect the parameters, which also creates storage to store the
 -- vector we will multiply with the Hessian, and to store the result (which the
 -- R-op applied to the parameters).
-local parameters, _, rParameters, rGradParameters = model:getParameters()
-parameters:fill(1)
+local parameters, gradParameters, rParameters, rGradParameters = model:getParameters()
+parameters:randn(parameters:size()) 
+
 
 -- Set rParameters to the vector you want to multiply the Hessian with
-rParameters:fill(1)
+rParameters:randn(parameters:size())
 
 -- First do the normal forward and backward-propagation
-model:forward(input)
+local pred = model:forward(input)
+local obj = criterion:forward(pred, target)
 
--- Here we assume that the sum of the output is the cost, so the gradient is a
--- tensor of ones.
-model:backward(input, torch.ones(mini_batch_size,  4))
+local df_do = criterion:backward(pred, target)
+model:backward(input, df_do)
 
 -- We calculate the R-ops as we go forward
-model:rForward(input)
+local r_pred = model:rForward(input)
 
--- Since we assumed the cost to be the sum of the outputs, the second
--- derivative is zero which means that R(dE/dy) is zero.
-model:rBackward(input, torch.zeros(mini_batch_size, 3), 
-      torch.ones(mini_batch_size, 4), torch.zeros( mini_batch_size, 4)) 
+local rGradOutput =  criterion:rBackward(r_pred, target)
+model:rBackward(input, torch.zeros(mini_batch_size, input_size), df_do, rGradOutput)
+
 
 -- The R-op applied to the parameters now contains the Hessian times the value
 -- of rParameters

--- a/rop.lua
+++ b/rop.lua
@@ -299,7 +299,7 @@ function LogSoftMax:updateROutput(input, rInput)
   return self.rOutput
 end
 
--- here is the explanation: https://cswhjiang.github.io/2015/10/13/Roperator/
+-- explanations: https://cswhjiang.github.io/2015/10/13/Roperator/
 function LogSoftMax:updateRGradInput(input, rInput, gradOutput, rGradOutput)
   if input:dim() == 1 then
     self.rGradInput:resizeAs(rGradOutput)

--- a/rop.lua
+++ b/rop.lua
@@ -299,6 +299,7 @@ function LogSoftMax:updateROutput(input, rInput)
   return self.rOutput
 end
 
+-- here is the explanation: https://cswhjiang.github.io/2015/10/13/Roperator/
 function LogSoftMax:updateRGradInput(input, rInput, gradOutput, rGradOutput)
   if input:dim() == 1 then
     self.rGradInput:resizeAs(rGradOutput)


### PR DESCRIPTION
I added support for LogSoftMax model, MSECriterion and ClassNLLCriterion. The LogSoftMax model does not pass the [test](https://gist.github.com/cswhjiang/a57e51d53fb45d850cc2). The checking method is Eq. (1) in Barak Pearlmutter's paper, which might not be accurate enough. Comparing the results with Theano is needed.
